### PR TITLE
Updated "umb-box-header"

### DIFF
--- a/UmbSense/Completion/Directives/UmbBoxHeader.cs
+++ b/UmbSense/Completion/Directives/UmbBoxHeader.cs
@@ -12,10 +12,10 @@ namespace UmbSense.Completion.Directives
 
         protected override Dictionary<string, string> values => new Dictionary<string, string>()
         {
-            { "title", "Custom title text" },
-            { "titleKey", "The translation key from the language xml files" },
-            { "description", "Custom description text" },
-            { "descriptionKey", "The translation key from the language xml file" }
+            { "title", "Custom title text." },
+            { "title-key", "The translation key from the language XML files." },
+            { "description", "Custom description text." },
+            { "description-key", "The translation key from the language XML files." }
         };
     }
 }


### PR DESCRIPTION
Fixes the casing of the attribute names.