### PR TITLE
Added `footer` attribute to the `umb-editor-view` directive

### DIFF
--- a/UmbSense/Completion/Directives/UmbEditorView.cs
+++ b/UmbSense/Completion/Directives/UmbEditorView.cs
@@ -17,4 +17,24 @@ namespace UmbSense.Completion.Directives
             { UmbEditorFooter.TagName, "Use this directive to construct a footer inside the main editor window." }
         };
     }
+
+    [HtmlCompletionProvider(CompletionTypes.Attributes, UmbEditorView.TagName)]
+    [ContentType("htmlx")]
+    class UmbEditorViewAttributes : BaseCompletion
+    {
+        protected override Dictionary<string, string> values => new Dictionary<string, string>()
+        {
+            { "footer", "Set to display the footer." },
+        };
+    }
+
+    [HtmlCompletionProvider(CompletionTypes.Values, UmbEditorView.TagName, "*")]
+    [ContentType("htmlx")]
+    class UmbEditorViewValues : BaseValueCompletion
+    {
+        protected override Dictionary<string, List<string>> attribValues => new Dictionary<string, List<string>>()
+        {
+            { "footer", new List<string> { "true", "false" } },
+        };
+    }
 }


### PR DESCRIPTION
I've noticed that the `<umb-editor-view>` directive has an [undocumented attribute for `footer="false"`](https://github.com/umbraco/Umbraco-CMS/blob/release-8.6.4/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorview.directive.js#L71-L73), so I've added that in.