### PR TITLE
Directive tags: umb-a* to umb-b*

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
                 "./tags/umb-box.html-data.json",
                 "./tags/umb-box-content.html-data.json",
                 "./tags/umb-box-header.html-data.json",
+                "./tags/umb-breadcrumbs.html-data.json",
                 "./tags/umb-button.html-data.json"
             ]
         }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
             "customData": [
                 "./tags/umb-avatar.html-data.json",
                 "./tags/umb-badge.html-data.json",
+                "./tags/umb-box.html-data.json",
+                "./tags/umb-box-content.html-data.json",
+                "./tags/umb-box-header.html-data.json",
                 "./tags/umb-button.html-data.json"
             ]
         }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "html": {
             "customData": [
                 "./tags/umb-avatar.html-data.json",
+                "./tags/umb-badge.html-data.json",
                 "./tags/umb-button.html-data.json"
             ]
         }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "contributes": {
         "html": {
             "customData": [
+                "./tags/umb-avatar.html-data.json",
                 "./tags/umb-button.html-data.json"
             ]
         }

--- a/tags/umb-avatar.html-data.json
+++ b/tags/umb-avatar.html-data.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vscode-html-languageservice/master/docs/customData.schema.json",
+  "version": 1.1,
+  "tags": [
+    {
+      "name": "umb-avatar",
+      "description": "### Umbraco avatar \n\n Usage: \n\n ```html \n <umb-avatar \n    size='{string}' \n    img-src='{string}' \n    img-srcset='{string}'>\n</umb-avatar> \n ```\n\n Required properties: `size`, `img-src`, `img-srcset`",
+      "attributes": [
+        {
+          "name": "size",
+          "description": "The size of the avatar \n\n Options: `xs`, `s`, `m`, `l`, `xl` \n\n Type: `string`",
+          "values": [
+            { "name": "xs" },
+            { "name": "s" },
+            { "name": "m" },
+            { "name": "l" },
+            { "name": "xl" }
+        ]
+        },
+        {
+          "name": "img-src",
+          "description": "The image source to the avatar \n\n Type: `string`"
+        },
+        {
+          "name": "img-srcset",
+          "description": "Reponsive support for the image source \n\n Type: `string`"
+        }
+      ],
+      "references": [
+        {
+          "name": "Umbraco API Docs V8 > Umbraco avatar directive `umbAvatar`",
+          "url": "https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbAvatar"
+        }
+      ]
+    }
+  ]
+}

--- a/tags/umb-avatar.html-data.json
+++ b/tags/umb-avatar.html-data.json
@@ -4,7 +4,7 @@
     "tags": [
         {
             "name": "umb-avatar",
-            "description": "### Umbraco avatar \n\n Usage: \n\n ```html \n <umb-avatar \n    size='{string}' \n    img-src='{string}' \n    img-srcset='{string}'>\n</umb-avatar> \n ```\n\n Required properties: `size`, `img-src`, `img-srcset`",
+            "description": "### Umbraco avatar \n\n Usage: \n\n ```html \n <umb-avatar \n    size='{string}' \n    img-src='{string}' \n    img-srcset='{string}'>\n</umb-avatar> \n ```",
             "attributes": [
                 {
                     "name": "size",

--- a/tags/umb-badge.html-data.json
+++ b/tags/umb-badge.html-data.json
@@ -3,12 +3,12 @@
     "version": 1.1,
     "tags": [
         {
-            "name": "umb-avatar",
-            "description": "### Umbraco avatar \n\n Usage: \n\n ```html \n <umb-avatar \n    size='{string}' \n    img-src='{string}' \n    img-srcset='{string}'>\n</umb-avatar> \n ```\n\n Required properties: `size`, `img-src`, `img-srcset`",
+            "name": "umb-badge",
+            "description": "### Umbraco badge \n\n Usage: \n\n ```html \n <umb-badge \n    size='{string}' \n    color='{string}'>\n</umb-badge> \n ```\n\n Required properties: `size`, `color`",
             "attributes": [
                 {
                     "name": "size",
-                    "description": "The size of the avatar \n\n Options: `xs`, `s`, `m`, `l`, `xl` \n\n Type: `string`",
+                    "description": "The badge size. \n\n Options: `xxs`, `xs`, `s`, `m`, `l`, `xl` \n\n Type: `string`",
                     "values": [
                         {
                             "name": "xs"
@@ -28,18 +28,14 @@
                     ]
                 },
                 {
-                    "name": "img-src",
-                    "description": "The image source to the avatar \n\n Type: `string`"
-                },
-                {
-                    "name": "img-srcset",
-                    "description": "Reponsive support for the image source \n\n Type: `string`"
+                    "name": "color",
+                    "description": "The color of the highlight. \n\n Examples: `primary`, `secondary`, `success`, `warning`, `danger`, `gray` \n\n Type: `string`"
                 }
             ],
             "references": [
                 {
-                    "name": "Umbraco API Docs V8 > Umbraco badge directive `umbAvatar`",
-                    "url": "https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbAvatar"
+                    "name": "Umbraco API Docs V8 > Umbraco badge directive `umbBadge`",
+                    "url": "https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBadge"
                 }
             ]
         }

--- a/tags/umb-badge.html-data.json
+++ b/tags/umb-badge.html-data.json
@@ -4,7 +4,7 @@
     "tags": [
         {
             "name": "umb-badge",
-            "description": "### Umbraco badge \n\n Usage: \n\n ```html \n <umb-badge \n    size='{string}' \n    color='{string}'>\n</umb-badge> \n ```\n\n Required properties: `size`, `color`",
+            "description": "### Umbraco badge \n\n Usage: \n\n ```html \n <umb-badge \n    size='{string}' \n    color='{string}'>\n</umb-badge> \n ```",
             "attributes": [
                 {
                     "name": "size",
@@ -29,7 +29,27 @@
                 },
                 {
                     "name": "color",
-                    "description": "The color of the highlight. \n\n Examples: `primary`, `secondary`, `success`, `warning`, `danger`, `gray` \n\n Type: `string`"
+                    "description": "The color of the highlight. \n\n Examples: `primary`, `secondary`, `success`, `warning`, `danger`, `gray` \n\n Type: `string`",
+                    "values": [
+                        {
+                            "name": "danger"
+                        },
+                        {
+                            "name": "gray"
+                        },
+                        {
+                            "name": "primary"
+                        },
+                        {
+                            "name": "secondary"
+                        },
+                        {
+                            "name": "success"
+                        },
+                        {
+                            "name": "warning"
+                        }
+                    ]
                 }
             ],
             "references": [

--- a/tags/umb-box-content.html-data.json
+++ b/tags/umb-box-content.html-data.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vscode-html-languageservice/master/docs/customData.schema.json",
+    "version": 1.1,
+    "tags": [
+        {
+            "name": "umb-box-content",
+            "description": "### Umbraco box content \n\n ```html \n Usage: <umb-box-content></umb-box-content> \n ```",
+            "references": [
+                {
+                    "name": "Umbraco API Docs V8 > Umbraco box content directive `umbBoxContent`",
+                    "url": "https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBoxContent"
+                }
+            ]
+        }
+    ]
+}

--- a/tags/umb-box-header.html-data.json
+++ b/tags/umb-box-header.html-data.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vscode-html-languageservice/master/docs/customData.schema.json",
+    "version": 1.1,
+    "tags": [
+        {
+            "name": "umb-box-header",
+            "description": "### Umbraco box header \n\n ```html \n Usage: <umb-box-header></umb-box-header> \n ```",
+            "attributes": [
+                {
+                    "name": "title",
+                    "description": " Custom title text. \n\n Type: `string`"
+                },
+                {
+                    "name": "title-key",
+                    "description": " The translation key from the language xml files. \n\n Type: `string`"
+                },
+                {
+                    "name": "description",
+                    "description": " Custom description text. \n\n Type: `string`"
+                },
+                {
+                    "name": "description-key",
+                    "description": " The translation key from the language xml files. \n\n Type: `string`"
+                }
+            ],
+            "references": [
+                {
+                    "name": "Umbraco API Docs V8 > Umbraco box header directive `umbBoxHeader`",
+                    "url": "https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBoxHeader"
+                }
+            ]
+        }
+    ]
+}

--- a/tags/umb-box-header.html-data.json
+++ b/tags/umb-box-header.html-data.json
@@ -4,7 +4,7 @@
     "tags": [
         {
             "name": "umb-box-header",
-            "description": "### Umbraco box header \n\n ```html \n Usage: <umb-box-header></umb-box-header> \n ```",
+            "description": "### Umbraco box header \n\n Usage: \n\n ```html \n <umb-box-header \n    [title='{string}'] \n    [title-key='{string}'] \n    [description='{string}'] \n    [description-key='{string}']>\n</umb-box-header> \n ```",
             "attributes": [
                 {
                     "name": "title",

--- a/tags/umb-box.html-data.json
+++ b/tags/umb-box.html-data.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vscode-html-languageservice/master/docs/customData.schema.json",
+    "version": 1.1,
+    "tags": [
+        {
+            "name": "umb-box",
+            "description": "### Umbraco box \n\n ```html \n Usage: <umb-box></umb-box> \n ```\n\n Child elements: \n\n* ```html \n <umb-box-header></umb-box-header> \n ```\n* ```html \n <umb-box-content></umb-box-content> \n ```",
+            "references": [
+                {
+                    "name": "Umbraco API Docs V8 > Umbraco box directive `umbBox`",
+                    "url": "https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBox"
+                }
+            ]
+        }
+    ]
+}

--- a/tags/umb-breadcrumbs.html-data.json
+++ b/tags/umb-breadcrumbs.html-data.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vscode-html-languageservice/master/docs/customData.schema.json",
+    "version": 1.1,
+    "tags": [
+        {
+            "name": "umb-breadcrumbs",
+            "description": "### Umbraco breadcrumbs \n Use this directive to generate a list of breadcrumbs. \n\n Usage: \n\n ```html \n <umb-breadcrumbs \n    ancestors='{array}' \n    entity-type='{string}' \n    [on-open='{callback}']>\n</umb-breadcrumbs> \n ```",
+            "attributes": [
+                {
+                    "name": "ancestors",
+                    "description": "Array of ancestors. \n\n Type: `array`"
+                },
+                {
+                    "name": "entity-type",
+                    "description": "The content entity type \n\n Options: `content`, `media`, `member` \n\n Type: `string`",
+                    "values": [
+                        {
+                            "name": "content"
+                        },
+                        {
+                            "name": "media"
+                        },
+                        {
+                            "name": "member"
+                        }
+                    ]
+                },
+                {
+                    "name": "on-open",
+                    "description": "Function callback when an ancestor is clicked. This will override the default link behaviour. \n\n Type: `callback function`"
+                }
+            ],
+            "references": [
+                {
+                    "name": "Umbraco API Docs V8 > Umbraco breadcrumbs directive `umbBreadcrumbs`",
+                    "url": "https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBreadcrumbs"
+                }
+            ]
+        }
+    ]
+}

--- a/tags/umb-button.html-data.json
+++ b/tags/umb-button.html-data.json
@@ -4,7 +4,7 @@
     "tags": [
         {
             "name": "umb-button",
-            "description": "### Umbraco button \n\n Usage: \n\n ```html \n <umb-button action='{string}'></umb-button> \n ```\n\n Required properties: `action`",
+            "description": "### Umbraco button \n\n ```html \n Usage: <umb-button action='{string}'></umb-button> \n ```\n\n Required properties: `action`",
             "attributes": [
                 {
                     "name": "action",

--- a/tags/umb-button.html-data.json
+++ b/tags/umb-button.html-data.json
@@ -4,11 +4,11 @@
     "tags": [
         {
             "name": "umb-button",
-            "description": "### Umbraco button \n\n ```html \n Usage: <umb-button action='{string}'></umb-button> \n ```\n\n Required properties: `action`",
+            "description": "### Umbraco button \n\n Usage: \n\n ```html \n <umb-button \n    action='{callback}' \n    [href='{string}'] \n    [type='{string}'] \n    [button-style='{string}'] \n    [state='{string}'] \n    [shortcut='{string}'] \n    [label='{string}'] \n    [label-key='{string}'] \n    [icon='{string}'] \n    [size='{string}'] \n    [disabled='{boolean}'] \n    [add-ellipsis='{boolean}'] \n    [show-caret='{boolean}'] \n    [auto-focus='{boolean}'] \n    [has-popup='{boolean}'] \n    [is-expanded='{boolean}']>\n</umb-button> \n ```",
             "attributes": [
                 {
                     "name": "action",
-                    "description": "The button action which should be performed when the button is clicked. \n\n Type: `string`"
+                    "description": "The button action which should be performed when the button is clicked. \n\n Type: `callback function`"
                 },
                 {
                     "name": "href",

--- a/tags/umb-button.html-data.json
+++ b/tags/umb-button.html-data.json
@@ -18,33 +18,63 @@
                     "name": "type",
                     "description": "Set the button type. \n\n Options: `button`, `link`, `submit` \n\n Type: `string`",
                     "values": [
-                        { "name": "button" },
-                        { "name": "link" },
-                        { "name": "submit" }
+                        {
+                            "name": "button"
+                        },
+                        {
+                            "name": "link"
+                        },
+                        {
+                            "name": "submit"
+                        }
                     ]
                 },
                 {
                     "name": "button-style",
                     "description": "Set the style of the button. \n\n Options: `block`, `danger`, `info`, `inverse`, `link`, `primary`, `success`, `warning` \n\n Pass in an array to add multiple styles `[success,block]`",
                     "values": [
-                        { "name": "primary" },
-                        { "name": "success" },
-                        { "name": "info"},
-                        { "name": "warning"},
-                        { "name": "danger"},
-                        { "name": "inverse"},
-                        { "name": "link"},
-                        { "name": "block"}
+                        {
+                            "name": "primary"
+                        },
+                        {
+                            "name": "success"
+                        },
+                        {
+                            "name": "info"
+                        },
+                        {
+                            "name": "warning"
+                        },
+                        {
+                            "name": "danger"
+                        },
+                        {
+                            "name": "inverse"
+                        },
+                        {
+                            "name": "link"
+                        },
+                        {
+                            "name": "block"
+                        }
                     ]
                 },
                 {
                     "name": "state",
                     "description": "Set a progress state on the button \n\n Options: `busy`, `error`, `init`, `success` \n\n Type: `string`",
-                    "values": [ 
-                        { "name": "busy"},
-                        { "name": "error"},
-                        { "name": "init"},
-                        { "name": "success"}
+                    "values": [
+                        {
+                            "name": "busy"
+                        },
+                        {
+                            "name": "error"
+                        },
+                        {
+                            "name": "init"
+                        },
+                        {
+                            "name": "success"
+                        }
                     ]
                 },
                 {
@@ -72,11 +102,19 @@
                 {
                     "name": "size",
                     "description": "Size of button \n\n Options: `xs`, `m`, `l`, `xl` \n\n Type: `string`",
-                    "values": [ 
-                        { "name": "xs"},
-                        { "name": "m"},
-                        { "name": "l"},
-                        { "name": "xl"}
+                    "values": [
+                        {
+                            "name": "xs"
+                        },
+                        {
+                            "name": "m"
+                        },
+                        {
+                            "name": "l"
+                        },
+                        {
+                            "name": "xl"
+                        }
                     ]
                 },
                 {


### PR DESCRIPTION
Added tags for:

- `umb-avatar`
- `umb-badge`
- `umb-box`
- `umb-box-content`
- `umb-box-header`
- `umb-breadcrumbs`

![test-1603283635774](https://user-images.githubusercontent.com/6873029/96720084-3b923780-13a2-11eb-9708-0836ffd123c3.gif)

N.B.
Based on the work to interrogate the usage of these directives in the source code and HTML mark-up, I have also raised a couple of PRs against the CMS source to reflect accurate documentation of usage:
- https://github.com/umbraco/Umbraco-CMS/pull/9230/files
- https://github.com/umbraco/Umbraco-CMS/pull/9240/files

